### PR TITLE
Fix serviceIDs key in create token payload

### DIFF
--- a/plugin/path_generate.go
+++ b/plugin/path_generate.go
@@ -138,7 +138,7 @@ func validateAndPreprocessInputParams(data *framework.FieldData) (map[string][]s
 	serviceIDs := strings.Split(data.Get("service_id").(string), ",")
 
 	originTTLString := data.Get("ttl").(string)
-	
+
 	// The default ttl for tokens is 5min(300s)
 	if len(originTTLString) == 0 {
 		originTTLString = "300"

--- a/plugin/path_generate.go
+++ b/plugin/path_generate.go
@@ -153,7 +153,7 @@ func validateAndPreprocessInputParams(data *framework.FieldData) (map[string][]s
 
 	validatedData := map[string][]string{
 		"scope":      []string{scope},
-		"services[]": serviceIDs,
+		"serviceIDs": serviceIDs,
 		"expires_at": []string{expiresAt},
 	}
 


### PR DESCRIPTION
Fixes a mismatch between what `validateAndPreprocessInputParams` returns (`services[]`) and how that value is referenced when constructing the create Token `formData` map (`serviceIDs`). Without this, or a similar, change, the `service_id` parameter on the generate path is effectively ignored.